### PR TITLE
Remove range parameter as it is unused

### DIFF
--- a/source/reference/parameters.rst
+++ b/source/reference/parameters.rst
@@ -27,11 +27,6 @@ JSON Schema `types/formats <https://json-schema.org/latest/json-schema-validatio
 * ``dateRange``: a range of dates, specified in the STAC format using
   ISO dates, for example:
   ``"2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"``
-* ``range``: a numerical range (either integers or floats). Range
-  parameters can specify the following additional options:
-  - ``min``: a minimum value
-  - ``max``: a maximum value
-  - ``type``: either ``integer`` or ``float``, depending on what values the block accepts
 * ``string``: generic string content. May be the empty string or ``null``
 * ``number``: generic number content, either integer or float, or ``null``
 * ``array``: a simple array of strings or numbers, an empty array, or ``null``


### PR DESCRIPTION
The range parameter was never used. To avoid confusion it is better to remove it - Sandor is about to remove it from the specifications.

### Checklist

- [ ] Checked spelling and grammar
- [ ] Provided code samples where relevant
- [ ] Checked the output of `make html` to ensure new content displays correctly
