### PR TITLE
Add size warning for K-Means Clustering

### DIFF
--- a/source/up42-blocks/processing/kmeans-clustering.rst
+++ b/source/up42-blocks/processing/kmeans-clustering.rst
@@ -12,6 +12,11 @@ Block type: ``PROCESSING``
 
 This block provides a simple `unsupervised classification <https://en.wikipedia.org/wiki/Cluster_analysis>`_ algorithm - K-Means clustering. It will create a set number of classes in each dataset and classify each pixel in one of this classes.
 
+.. warning::
+   This block can only process imagery **up to 1.2GB** size, since it requires the entire
+   image to be loaded at once into memory. Any imagery with a larger size
+   will result in an error.
+
 Supported parameters
 --------------------
 

--- a/source/up42-blocks/processing/kmeans-clustering.rst
+++ b/source/up42-blocks/processing/kmeans-clustering.rst
@@ -13,7 +13,7 @@ Block type: ``PROCESSING``
 This block provides a simple `unsupervised classification <https://en.wikipedia.org/wiki/Cluster_analysis>`_ algorithm - K-Means clustering. It will create a set number of classes in each dataset and classify each pixel in one of this classes.
 
 .. warning::
-   This block can only process imagery **up to 1.2GB** size, since it requires the entire
+   This block can only process imagery **up to size of 1.2GB** size, since it requires the entire
    image to be loaded at once into memory. Any imagery with a larger size
    will result in an error.
 


### PR DESCRIPTION
Pull Request
============

> Tracked in JIRA by [UP-4611](https://geoinformationstore.atlassian.net/browse/UP-4611)

### Scope of the PR

Add maximum 1.2GB size warning into kmeans clustering docs.

### Checklist

- [x] Checked spelling and grammar
- [na] Provided code samples where relevant
- [x] Checked the output of `make html` to ensure new content displays correctly
