### PR TITLE
Add compatibility with hexagon to NDVI docs and new sensor types

### DIFF
--- a/source/reference/capabilities.rst
+++ b/source/reference/capabilities.rst
@@ -309,6 +309,10 @@ up42_standard raster capabilities
         - Sentinel2
         - Sentinel3
         - Sentinel 5P
+        - Landsat8
+        - MODIS
+        - Meteomatics
+        - Hexagon
 
     resolution
         The resolution of the raster image im meters, for blocks providing

--- a/source/up42-blocks/processing/ndvi.rst
+++ b/source/up42-blocks/processing/ndvi.rst
@@ -4,8 +4,8 @@
 
 .. _ndvi-block:
 
-NDVI SPOT/Pléiades/Hexagon
-==========================
+NDVI
+====
 For more information, please read the `block description <https://marketplace.up42.com/block/d0da4ac9-94c6-4905-80f5-c95e702ca878>`_.
 
 Block type: ``PROCESSING``

--- a/source/up42-blocks/processing/ndvi.rst
+++ b/source/up42-blocks/processing/ndvi.rst
@@ -10,7 +10,7 @@ For more information, please read the `block description <https://marketplace.up
 
 Block type: ``PROCESSING``
 
-This block computes the Normalized Difference Vegetation Index (NDVI) from Pléiades or SPOT images that include a NIR band.
+This block computes the Normalized Difference Vegetation Index (NDVI) from Pléiades, SPOT or Hexagon images that include a NIR band.
 This block can only process outputs from the blocks :ref:`Pléiades Download <pleiades-download-block>` or
 :ref:`SPOT 6/7 Download <spot-download-block>`, which have been converted to GeoTIFF with the
 blocks :ref:`DIMAP -> GeoTIFF Conversion <dimap-conversion-block>` or :ref:`Pan-sharpening SPOT/Pléiades <pansharpen-block>` .

--- a/source/up42-blocks/processing/ndvi.rst
+++ b/source/up42-blocks/processing/ndvi.rst
@@ -1,11 +1,11 @@
 .. meta::
    :description: UP42 processing blocks: NDVI block description
-   :keywords: UP42, processing, NDVI, vegetation, SPOT 6/7, Pléiades, block description
+   :keywords: UP42, processing, NDVI, vegetation, SPOT 6/7, Pléiades, Hexagon, block description
 
 .. _ndvi-block:
 
-NDVI SPOT/Pléiades
-==================
+NDVI SPOT/Pléiades/Hexagon
+==========================
 For more information, please read the `block description <https://marketplace.up42.com/block/d0da4ac9-94c6-4905-80f5-c95e702ca878>`_.
 
 Block type: ``PROCESSING``


### PR DESCRIPTION
Pull Request
============

> Tracked in JIRA https://up42.atlassian.net/browse/UP-4912?atlOrigin=eyJpIjoiODc0OTNmOTE2YWM4NDY3M2JjMWU1YWE2ZGY5M2NiZjAiLCJwIjoiaiJ9

### Scope of the PR

NDVI processing block is now also compatible with hexagon data. Added this information to the documentation.
Also updated the list of sensors for the block capabilities (from here https://github.com/up42/specifications/blob/master/v2/blocks/raster-types-schema.json)

### Checklist

- [x] Checked spelling and grammar
- [x] Checked the output of `make html` to ensure new content displays correctly
- [x] Ask Niklas to update marketplace with new Hexagon compatibility


