### PR TITLE
Use asset_ids instead of asset_id

### DIFF
--- a/source/going-further/download-blocks-tutorial-spot-pleiades.rst
+++ b/source/going-further/download-blocks-tutorial-spot-pleiades.rst
@@ -249,16 +249,16 @@ workflow:
 
 .. gist:: https://gist.github.com/up42-epicycles/be903d94b904d2011b044ce472065b17
 
-You can see the field ``asset_id``:
+You can see the field ``asset_ids``:
 
 .. code:: javascript
 
    ...
-   "asset_id":
-      "002e11d3-3b46-43a5-a07d-855a94c72817",
+   "asset_ids":
+      ["002e11d3-3b46-43a5-a07d-855a94c72817"],
    ...
 
-which is a single asset ID.
+which is an array with a single asset ID.
 
 And the output shown here as a GeoTIFF.
 

--- a/source/up42-blocks/data/pleiades-display-download.rst
+++ b/source/up42-blocks/data/pleiades-display-download.rst
@@ -39,7 +39,7 @@ For more information, please read the section :ref:`Data source query filters  <
 * ``limit``: An integer number of maximum results to return. The maximum value for ``limit`` is 500.
 * ``ids``: An array of image identifiers as defined by the ``parentIdentifier`` property. If defined, either ``bbox`` **or** ``intersects`` **or** ``contains`` should be selected as well. By defining the ``ids`` filter you specify unambiguously which images to retrieve based solely on your AOI and given ID(s). The ``ids`` filter overrides all other filters, e.g., ``limit`` and/or ``time``.
 * ``max_cloud_cover``: A percentage (0 to 100) defining the maximum :term:`cloud cover` of any returned imagery. Note that the cloud cover percentage is computed with the full scene, not the requested geographical area. Default is **100**.
-* ``asset_id``: An asset identifier for a particular item in your UP42 Storage, see the :ref:`Download blocks tutorial  <download-blocks-tutorial-spot-pleiades>` for an explanation.
+* ``asset_ids``: An array of asset identifiers for a particular item in your UP42 Storage, see the :ref:`Download blocks tutorial  <download-blocks-tutorial-spot-pleiades>` for an explanation.
 
 
 Example queries

--- a/source/up42-blocks/data/pleiades-reflectance-download.rst
+++ b/source/up42-blocks/data/pleiades-reflectance-download.rst
@@ -38,7 +38,7 @@ For more information, please read the section :ref:`Data source query filters  <
 * ``limit``: An integer number of maximum results to return. The maximum value for ``limit`` is 500.
 * ``ids``: An array of image identifiers as defined by the ``parentIdentifier`` property. If defined, either ``bbox`` **or** ``intersects`` **or** ``contains`` should be selected as well. By defining the ``ids`` filter you specify unambiguously which images to retrieve based solely on your AOI and given ID(s). The ``ids`` filter overrides all other filters, e.g., ``limit`` and/or ``time``.
 * ``max_cloud_cover``: A percentage (0 to 100) defining the maximum :term:`cloud cover` of any returned imagery. Note that the cloud cover percentage is computed with the full scene, not the requested geographical area. Default is **100**.
-* ``asset_id``: An asset identifier for a particular item in your UP42 Storage, see the :ref:`Download blocks tutorial  <download-blocks-tutorial-spot-pleiades>` for an explanation.
+* ``asset_ids``: An array of asset identifiers for a particular item in your UP42 Storage, see the :ref:`Download blocks tutorial  <download-blocks-tutorial-spot-pleiades>` for an explanation.
 
 
 Example queries

--- a/source/up42-blocks/data/spot-display-download.rst
+++ b/source/up42-blocks/data/spot-display-download.rst
@@ -39,7 +39,7 @@ For more information, please read the section :ref:`Data source query filters  <
 * ``limit``: An integer number of maximum results to return. The maximum value for ``limit`` is 500.
 * ``ids``: An array of image identifiers as defined by the ``parentIdentifier`` property. If defined, either ``bbox`` **or** ``intersects`` **or** ``contains`` should be selected as well.  By defining the ``ids`` filter you specify unambiguously which images to retrieve based solely on your AOI and given ID(s). The ``ids`` filter overrides all other filters, e.g., ``limit`` and/or ``time``.
 * ``max_cloud_cover``: A percentage (0 to 100) defining the maximum :term:`cloud cover` of any returned imagery. Note that the cloud cover percentage is computed with the full scene, not the requested geographical area. Default is **100**.
-* ``asset_id``: An asset identifier for a particular item in your UP42 Storage, see the :ref:`Download blocks tutorial  <download-blocks-tutorial-spot-pleiades>` for an explanation.
+* ``asset_ids``: An array of asset identifiers for a particular item in your UP42 Storage, see the :ref:`Download blocks tutorial  <download-blocks-tutorial-spot-pleiades>` for an explanation.
 
 
 Example queries

--- a/source/up42-blocks/data/spot-reflectance-download.rst
+++ b/source/up42-blocks/data/spot-reflectance-download.rst
@@ -38,7 +38,7 @@ For more information, please read the section :ref:`Data source query filters  <
 * ``limit``: An integer number of maximum results to return. The maximum value for ``limit`` is 500.
 * ``ids``: An array of image identifiers as defined by the ``parentIdentifier`` property. If defined, either ``bbox`` **or** ``intersects`` **or** ``contains`` should be selected as well.  By defining the ``ids`` filter you specify unambiguously which images to retrieve based solely on your AOI and given ID(s). The ``ids`` filter overrides all other filters, e.g., ``limit`` and/or ``time``.
 * ``max_cloud_cover``: A percentage (0 to 100) defining the maximum :term:`cloud cover` of any returned imagery. Note that the cloud cover percentage is computed with the full scene, not the requested geographical area. Default is **100**.
-* ``asset_id``: An asset identifier for a particular item in your UP42 Storage, see the :ref:`Download blocks tutorial  <download-blocks-tutorial-spot-pleiades>` for an explanation.
+* ``asset_ids``: An array of asset identifiers for a particular item in your UP42 Storage, see the :ref:`Download blocks tutorial  <download-blocks-tutorial-spot-pleiades>` for an explanation.
 
 
 Example queries


### PR DESCRIPTION
Pull Request
============

> Tracked in JIRA by [UP-5139](https://geoinformationstore.atlassian.net/browse/IN-5139)

### Scope of the PR

Asset_id is now replaced by asset_ids. That means each job will now support several asset ids as input parameters.
@perusio can you please update the gist https://gist.github.com/up42-epicycles/be903d94b904d2011b044ce472065b17 accordingly? 

### Checklist

- [x] Checked spelling and grammar
- [x] Provided code samples where relevant
- [x] Checked the output of `make html` to ensure new content displays correctly
