### PR TITLE
Clarify that spot/phr expecting blocks can use the export geotiff blo…

### DIFF
--- a/source/up42-blocks/data/geotiff-custom.rst
+++ b/source/up42-blocks/data/geotiff-custom.rst
@@ -18,6 +18,9 @@ location and time. The search can also be limited to a subfolder in the bucket v
 `prefix` parameter.
 The block outputs the scene data and an automatically created `data.json` file with the scene metadata.
 
+The block can connect to any processing block which expects output from the SPOT or Pléiades sensor or is
+sensor-agnostic (i.e. does not expect any specific sensor).
+
 .. tip::
 
     In order to access the bucket, the access credentials need to be provided via UP42 environment variables.


### PR DESCRIPTION
Pull Request
============

> Tracked in JIRA by [UP-5141](https://up42.atlassian.net/browse/UP-5141)


### Scope of the PR

Documenting a change that allows processing blocks expecting SPOT or Pleiades imagery to use the import geotiff block as input.


### Checklist

- [x] Checked spelling and grammar
- [ ] Provided code samples where relevant
- [x] Checked the output of `make html` to ensure new content displays correctly
