### PR TITLE
Add full scene ordering up5231

### DIFF
--- a/source/up42-blocks/data/pleiades-display-download.rst
+++ b/source/up42-blocks/data/pleiades-display-download.rst
@@ -37,11 +37,14 @@ For more information, please read the section :ref:`Data source query filters  <
 * ``time``: A date range to filter scenes on. This range applies to the acquisition date/time of the scenes.
 * ``time_series``: An array of date range filters as defined by ``time``. If defined, the ``limit`` parameter applies to each date range individually and the ``time`` filter is ignored.
 * ``limit``: An integer number of maximum results to return. The maximum value for ``limit`` is 500.
-* ``ids``: An array of image identifiers as defined by the ``parentIdentifier`` property. If defined, either ``bbox`` **or** ``intersects`` **or** ``contains`` should be selected as well. By defining the ``ids`` filter you specify unambiguously which images to retrieve based solely on your AOI and given ID(s). The ``ids`` filter overrides all other filters, e.g., ``limit`` and/or ``time``.
+* ``ids``: An array of image identifiers as defined by the ``parentIdentifier`` property. If defined, without ``bbox`` **or** ``intersects`` **or** ``contains``, the full scene will be ordered. Use ``bbox``, ``intersects`` **or** ``contains`` if you'd like to clip the scene to that AOI. By defining the ``ids`` filter you specify unambiguously which images to retrieve based solely on your AOI and given ID(s). The ``ids`` filter overrides all other filters, e.g., ``limit`` and/or ``time``.
 * ``max_cloud_cover``: A percentage (0 to 100) defining the maximum :term:`cloud cover` of any returned imagery. Note that the cloud cover percentage is computed with the full scene, not the requested geographical area. Default is **100**.
 * ``asset_ids``: An array of asset identifiers for a particular item in your UP42 Storage, see the :ref:`Download blocks tutorial  <download-blocks-tutorial-spot-pleiades>` for an explanation.
 
-
+.. warning::
+  Using ``ids`` as parameter, without ``bbox`` **or** ``intersects`` **or** ``contains`` enables you to order the full scene. Ordering of a full scene is costly! Make sure this is intended and make use of the
+  ``bbox`` **or** ``intersects`` **or** ``contains`` if you want to order a subset of the scene.
+  
 Example queries
 ---------------
 

--- a/source/up42-blocks/data/pleiades-reflectance-download.rst
+++ b/source/up42-blocks/data/pleiades-reflectance-download.rst
@@ -36,10 +36,13 @@ For more information, please read the section :ref:`Data source query filters  <
 * ``time``: A date range to filter scenes on. This range applies to the acquisition date/time of the scenes.
 * ``time_series``: An array of date range filters as defined by ``time``. If defined, the ``limit`` parameter applies to each date range individually and the ``time`` filter is ignored.
 * ``limit``: An integer number of maximum results to return. The maximum value for ``limit`` is 500.
-* ``ids``: An array of image identifiers as defined by the ``parentIdentifier`` property. If defined, either ``bbox`` **or** ``intersects`` **or** ``contains`` should be selected as well. By defining the ``ids`` filter you specify unambiguously which images to retrieve based solely on your AOI and given ID(s). The ``ids`` filter overrides all other filters, e.g., ``limit`` and/or ``time``.
+* ``ids``: An array of image identifiers as defined by the ``parentIdentifier`` property. If defined, without ``bbox`` **or** ``intersects`` **or** ``contains``, the full scene will be ordered. Use ``bbox``, ``intersects`` **or** ``contains`` if you'd like to clip the scene to that AOI. By defining the ``ids`` filter you specify unambiguously which images to retrieve based solely on your AOI and given ID(s). The ``ids`` filter overrides all other filters, e.g., ``limit`` and/or ``time``.
 * ``max_cloud_cover``: A percentage (0 to 100) defining the maximum :term:`cloud cover` of any returned imagery. Note that the cloud cover percentage is computed with the full scene, not the requested geographical area. Default is **100**.
 * ``asset_ids``: An array of asset identifiers for a particular item in your UP42 Storage, see the :ref:`Download blocks tutorial  <download-blocks-tutorial-spot-pleiades>` for an explanation.
 
+.. warning::
+  Using ``ids`` as parameter, without ``bbox`` **or** ``intersects`` **or** ``contains`` enables you to order the full scene. Ordering of a full scene is costly! Make sure this is intended and make use of the
+  ``bbox`` **or** ``intersects`` **or** ``contains`` if you want to order a subset of the scene.
 
 Example queries
 ---------------

--- a/source/up42-blocks/data/spot-display-download.rst
+++ b/source/up42-blocks/data/spot-display-download.rst
@@ -37,10 +37,14 @@ For more information, please read the section :ref:`Data source query filters  <
 * ``time``: A date range to filter scenes on. This range applies to the acquisition date/time of the scenes.
 * ``time_series``: An array of date range filters as defined by ``time``. If defined, the ``limit`` parameter applies to each date range individually and the ``time`` filter is ignored.
 * ``limit``: An integer number of maximum results to return. The maximum value for ``limit`` is 500.
-* ``ids``: An array of image identifiers as defined by the ``parentIdentifier`` property. If defined, either ``bbox`` **or** ``intersects`` **or** ``contains`` should be selected as well.  By defining the ``ids`` filter you specify unambiguously which images to retrieve based solely on your AOI and given ID(s). The ``ids`` filter overrides all other filters, e.g., ``limit`` and/or ``time``.
+* ``ids``: An array of image identifiers as defined by the ``parentIdentifier`` property. If defined, without ``bbox`` **or** ``intersects`` **or** ``contains``, the full scene will be ordered. Use ``bbox``, ``intersects`` **or** ``contains`` if you'd like to clip the scene to that AOI. By defining the ``ids`` filter you specify unambiguously which images to retrieve based solely on your AOI and given ID(s). The ``ids`` filter overrides all other filters, e.g., ``limit`` and/or ``time``.
 * ``max_cloud_cover``: A percentage (0 to 100) defining the maximum :term:`cloud cover` of any returned imagery. Note that the cloud cover percentage is computed with the full scene, not the requested geographical area. Default is **100**.
 * ``asset_ids``: An array of asset identifiers for a particular item in your UP42 Storage, see the :ref:`Download blocks tutorial  <download-blocks-tutorial-spot-pleiades>` for an explanation.
 
+.. warning::
+  Using ``ids`` as parameter, without ``bbox`` **or** ``intersects`` **or** ``contains`` enables you to order the full scene. Ordering of a full scene is costly! Make sure this is intended and make use of the
+  ``bbox`` **or** ``intersects`` **or** ``contains`` if you want to order a subset of the scene.
+  
 
 Example queries
 ---------------

--- a/source/up42-blocks/data/spot-display-streaming.rst
+++ b/source/up42-blocks/data/spot-display-streaming.rst
@@ -5,7 +5,7 @@
 .. _spot-aoiclipped-block:
 
 SPOT 6/7 Display (Streaming)
-=======================
+============================
 For more information, please read the `block description <https://marketplace.up42.com/block/045019bb-06fc-4fa1-b703-318725b4d8af>`_.
 
 Block type: ``DATA``

--- a/source/up42-blocks/data/spot-reflectance-download.rst
+++ b/source/up42-blocks/data/spot-reflectance-download.rst
@@ -36,11 +36,14 @@ For more information, please read the section :ref:`Data source query filters  <
 * ``time``: A date range to filter scenes on. This range applies to the acquisition date/time of the scenes.
 * ``time_series``: An array of date range filters as defined by ``time``. If defined, the ``limit`` parameter applies to each date range individually and the ``time`` filter is ignored.
 * ``limit``: An integer number of maximum results to return. The maximum value for ``limit`` is 500.
-* ``ids``: An array of image identifiers as defined by the ``parentIdentifier`` property. If defined, either ``bbox`` **or** ``intersects`` **or** ``contains`` should be selected as well.  By defining the ``ids`` filter you specify unambiguously which images to retrieve based solely on your AOI and given ID(s). The ``ids`` filter overrides all other filters, e.g., ``limit`` and/or ``time``.
+* ``ids``: An array of image identifiers as defined by the ``parentIdentifier`` property. If defined, without ``bbox`` **or** ``intersects`` **or** ``contains``, the full scene will be ordered. Use ``bbox``, ``intersects`` **or** ``contains`` if you'd like to clip the scene to that AOI. By defining the ``ids`` filter you specify unambiguously which images to retrieve based solely on your AOI and given ID(s). The ``ids`` filter overrides all other filters, e.g., ``limit`` and/or ``time``.
 * ``max_cloud_cover``: A percentage (0 to 100) defining the maximum :term:`cloud cover` of any returned imagery. Note that the cloud cover percentage is computed with the full scene, not the requested geographical area. Default is **100**.
 * ``asset_ids``: An array of asset identifiers for a particular item in your UP42 Storage, see the :ref:`Download blocks tutorial  <download-blocks-tutorial-spot-pleiades>` for an explanation.
 
-
+.. warning::
+  Using ``ids`` as parameter, without ``bbox`` **or** ``intersects`` **or** ``contains`` enables you to order the full scene. Ordering of a full scene is costly! Make sure this is intended and make use of the
+  ``bbox`` **or** ``intersects`` **or** ``contains`` if you want to order a subset of the scene.
+  
 Example queries
 ---------------
 


### PR DESCRIPTION
Pull Request
============

> Tracked in JIRA by [IN-XXX](https://geoinformationstore.atlassian.net/browse/UP-5231

### Scope of the PR

Add support for ordering full scenes in OneAtlas download blocks.

### Checklist

- [x] Checked spelling and grammar
- [x] Provided code samples where relevant
- [x] Checked the output of `make html` to ensure new content displays correctly
