### PR TITLE
Add provider name and quotes to polarization strings

### DIFF
--- a/source/up42-blocks/processing/snap-polarimetric.rst
+++ b/source/up42-blocks/processing/snap-polarimetric.rst
@@ -5,8 +5,8 @@
 
 .. _snap-polarimetric-block:
 
-SNAP Sentinel-1 Polarimetric Processing
-=======================================
+UP42 SNAP Sentinel-1 Polarimetric Processing
+============================================
 
 For more information, please read the `block description
 <https://marketplace.up42.com/block/8c6baae9-d50e-406c-b4ac-e211caa6229d>`_.
@@ -26,8 +26,8 @@ Supported parameters
 * ``intersects``: A GeoJSON geometry to use as an AOI. Will clip to scenes that intersect with this geometry. Use only ``bbox`` **or** ``intersects`` **or** ``contains``.
 * ``contains``: A GeoJSON geometry to use as an AOI. Will clip to scenes that intersect with this geometry. Use only ``bbox`` **or** ``intersects`` **or** ``contains``.
 * ``polarisations``: Requested polarisations, either **one and only
-  one** of: ``[VV,VH]``, ``[HH, HV]``, ``[VV]``,  ``[VH]``, ``[HV]``
-  or ``[HH]``. The operation will fail and give a corresponding error message if the requested polarization is not
+  one** of: ``["VV","VH"]``, ``["HH", "HV"]``, ``["VV"]``,  ``["VH"]``, ``["HV"]``
+  or ``["HH"]``. The operation will fail and give a corresponding error message if the requested polarization is not
   avialble in the input image to SNAP.
 * ``mask``: It applies a masks for either ``land`` or ``sea``. Use one
   and only one, you cannot chose both.


### PR DESCRIPTION
Pull Request
============

### Scope of the PR

I tried to copy over the polarisations into a job configuration and learned that I had to add double quotes, so I believe it is more user-friendly to have them in the docu.
Took the opportunity to add the provider - something that we want to do for all blocks.

### Checklist

- [x] Checked spelling and grammar
- [ ] Provided code samples where relevant
- [x] Checked the output of `make html` to ensure new content displays correctly
