### PR TITLE
Remove max image size for Vectorising

### DIFF
--- a/source/up42-blocks/processing/vectorization.rst
+++ b/source/up42-blocks/processing/vectorization.rst
@@ -16,7 +16,8 @@ This block vectorizes raster files into ``GeoJSON`` format.
 
   The input for this block should be a **thematic raster dataset** with relatively few
   possible values so that the output geometry is meaningful. A suitable input
-  is the result of a **K-Means Clustering** or a **Land Cover Classification**.
+  is the result of :ref:`K-Means Clustering <kmeans-clustering-block>`,
+  :ref:`Land Cover <land-cover-block>` or :ref:`NDVI Threshold <up42-ndvithreshold-block>`.
 
 Supported parameters
 --------------------

--- a/source/up42-blocks/processing/vectorization.rst
+++ b/source/up42-blocks/processing/vectorization.rst
@@ -18,13 +18,6 @@ This block vectorizes raster files into ``GeoJSON`` format.
   possible values so that the output geometry is meaningful. A suitable input
   is the result of a **K-Means Clustering** or a **Land Cover Classification**.
 
-.. warning::
-
-  Very large images (bigger than **40 MP**, or for example a 10 km :superscript:`2` image from Pléiades) are
-  not processable by this block. Please add the :ref:`Tiling block <tiling-block>` before the Vectorization
-  block to process very large images.
-
-
 Supported parameters
 --------------------
 


### PR DESCRIPTION
Pull Request
============

> Tracked in JIRA by [UP-5363](https://geoinformationstore.atlassian.net/browse/UP-5363)

### Scope of the PR

Removes the warning about the maximum image size given the tiled vectorising implementation in https://github.com/up42/blocks/pull/919. Block will now be able to process almost all the images being inputed.

### Checklist

- [x] Checked spelling and grammar
- [x] Provided code samples where relevant
- [x] Checked the output of `make html` to ensure new content displays correctly
